### PR TITLE
fix distant z-fighitng in reflective flats

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -323,7 +323,7 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 	int rel = getExtraLight();
 
 	state.SetNormal(plane.plane.Normal().X, plane.plane.Normal().Z, plane.plane.Normal().Y);
-	double zshift = (plane.plane.Normal().Z > 0.0 ? 0.01f : -0.01f); // The HWPlaneMirrorPortal::DrawPortalStencil() z-fights with flats
+	double zshift = (plane.plane.Normal().Z > 0.0 ? 0.1f : -0.1f); // The HWPlaneMirrorPortal::DrawPortalStencil() z-fights with flats
 
 	SetColor(state, di->Level, di->lightmode, lightlevel, rel, di->isFullbrightScene(), Colormap, alpha);
 	SetFog(state, di->Level, di->lightmode, lightlevel, rel, di->isFullbrightScene(), &Colormap, false);


### PR DESCRIPTION
Z-fighting between flat texture and stencil at long distances was occurring, showing up as a "shimmer" at a long distance from the camera. Just increasing the vertical shift of flat texture.

Addressing this bug: https://github.com/ZDoom/gzdoom/issues/3246